### PR TITLE
Clean up and separate the custom loading mechanism

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ SET(TF_LIB tensorflow-microlite)
 ADD_LIBRARY(${PROJECT_NAME} STATIC
     src/CodeWriter.cpp
     src/Compiler.cpp
+    src/CustomOperators.cpp
     src/TypeToString.cpp
     src/RecordAllocations.cpp
     src/MemMap.cpp

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LIBS=-L${TF_DIR}/tensorflow/lite/micro/tools/make/gen/linux_x86_64/lib/ \
 
 all: compiler examples
 
-compiler: src/main.o src/Compiler.o src/CodeWriter.o src/TypeToString.o src/RecordAllocations.o src/MemMap.o
+compiler: src/main.o src/Compiler.o src/CodeWriter.o src/TypeToString.o src/RecordAllocations.o src/MemMap.o src/CustomOperators.o
 	$(CXX) -o $@ $^ ${LIBS}
 
 clean: clean-compiler clean-examples

--- a/src/CustomOperators.cpp
+++ b/src/CustomOperators.cpp
@@ -53,10 +53,10 @@ void tflmc::UnloadCustom(tflmc::custom_operator_handle custom_lib) {
 
 #else
 // anyone interested in implementing this for Windows (LoadLibrary+GetProcAddr)
-tflmc::custom_operator_handle tflm::LoadCustom() {
+tflmc::custom_operator_handle tflmc::LoadCustom(tflite::AllOpsResolver *resolver) {
     return nullptr;
 }
 
-void tflmc::UnloadCustom(tflm::custom_operator_handle) {
+void tflmc::UnloadCustom(tflmc::custom_operator_handle) {
 }
 #endif

--- a/src/CustomOperators.cpp
+++ b/src/CustomOperators.cpp
@@ -1,0 +1,62 @@
+/* Copyright 2020 Christof Petig. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "CustomOperators.h"
+#include <iostream>
+#include <unistd.h>
+
+// dynamic loading for custom operators
+#ifndef _WIN32
+#include <dlfcn.h>
+
+tflmc::custom_operator_handle tflmc::LoadCustom(tflite::AllOpsResolver *resolver) {
+  const char* filename = "./libtflite_micro_custom.so";
+  void *custom_lib = dlopen(filename, RTLD_NOW);
+  if (custom_lib) {
+    TfLiteStatus (*reg_fun)(tflite::AllOpsResolver *res);
+    // see "man dlopen" for an explanation of this nasty construct
+    *(void **) (&reg_fun) = dlsym(custom_lib, "register_custom");
+    char *error = dlerror();
+    if (error) {
+      std::cerr << filename << ": " << error << "\n";
+    }
+    else if (reg_fun) {
+      (*reg_fun)(resolver);
+    }
+  }
+  else if (!access(filename, 0)) { // only output error if the plugin exists
+    char *error = dlerror();
+    if (error) {
+      std::cerr << filename << ": " << error << "\n";
+    }
+  }
+  return custom_lib;
+}
+
+void tflmc::UnloadCustom(tflmc::custom_operator_handle custom_lib) {
+  if (custom_lib) {
+    dlclose(custom_lib);
+  }
+}
+
+#else
+// anyone interested in implementing this for Windows (LoadLibrary+GetProcAddr)
+tflmc::custom_operator_handle tflm::LoadCustom() {
+    return nullptr;
+}
+
+void tflmc::UnloadCustom(tflm::custom_operator_handle) {
+}
+#endif

--- a/src/CustomOperators.h
+++ b/src/CustomOperators.h
@@ -1,0 +1,28 @@
+/* Copyright 2020 Christof Petig. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TFLMCOMPILER_CUSTOMOPERATORS_H
+#define TFLMCOMPILER_CUSTOMOPERATORS_H
+
+#include "tensorflow/lite/micro/all_ops_resolver.h"
+
+namespace tflmc {
+typedef void* custom_operator_handle;
+
+custom_operator_handle LoadCustom(tflite::AllOpsResolver *res);
+void UnloadCustom(custom_operator_handle);
+}
+
+#endif


### PR DESCRIPTION
... into a separate file and integrate it into both compiler and allocator run. 
Side effect: Fix compilation with current tensorflow master (another change required)

Motivation: Custom operators failed in the allocation phase.
