### PR TITLE
Fixed function naming for TF change https://github.com/tensorflow/tensorflow/commit/9d572b8d5efca020965a7915a3a465fb61a45ee3

### DIFF
--- a/src/RecordAllocations.cpp
+++ b/src/RecordAllocations.cpp
@@ -42,7 +42,7 @@ std::vector<tflmc::Allocation> tflmc::RecordAllocations(
   auto allocator = &interpreter.allocator_;
 
   tflite::NodeAndRegistration *nodeAndRegs;
-  allocator->InitializeFromFlatbuffer(resolver, &nodeAndRegs);
+  allocator->PrepareFromFlatbuffer(resolver, &nodeAndRegs);
 
   g_allocator = allocator;
   ctx->AllocatePersistentBuffer = &LoggingAllocatePersistentBuffer;


### PR DESCRIPTION
See upstream change [here](https://github.com/tensorflow/tensorflow/commit/9d572b8d5efca020965a7915a3a465fb61a45ee3)

Not sure if this upstream TF change effects the compiler's functionality. I was going to start working in to it today and this was my first build error.