### PR TITLE
Added functions to retrieve output dimensions

### DIFF
--- a/src/Compiler.cpp
+++ b/src/Compiler.cpp
@@ -429,6 +429,14 @@ TfLiteTensor* )"
       << prefix_ << R"(output(int index) {
   return &g_ctx.tensors[outTensorIndices[index]];
 }
+int )" << prefix_
+      << R"(output_dims_len(int index) {
+  return g_ctx.tensors[outTensorIndices[index]].dims->data[0];
+}
+const int *)"
+      << prefix_ << R"(output_dims(int index) {
+  return &g_ctx.tensors[outTensorIndices[index]].dims->data[1];
+}
 
 TfLiteStatus )"
       << prefix_ << R"(invoke() {


### PR DESCRIPTION
I don't know enough about TF tensor dimensioning yet but functions like these would help me with my hardware implementations :)

Mainly not sure if the tensor dimensions are always returned in an array (`int *`) or if this can vary in depth.