### PR TITLE
fix inference with latest tensorflow by introducing evaltensors into generated code

### DIFF
--- a/src/RecordAllocations.cpp
+++ b/src/RecordAllocations.cpp
@@ -77,3 +77,13 @@ std::vector<tflmc::Allocation> tflmc::RecordAllocations(
   tflmc::UnloadCustom(custom);
   return g_loggedAllocations;
 }
+
+TfLiteEvalTensor *tflmc::GetEvalTensor(tflite::MicroInterpreter *interpreter, int i) {
+  auto ctx = &interpreter->context_;
+  return ctx->GetEvalTensor(ctx, i);
+}
+
+TfLiteTensor *tflmc::GetTensor(tflite::MicroInterpreter *interpreter, int i) {
+  auto ctx = &interpreter->context_;
+  return ctx->GetTensor(ctx, i);
+}

--- a/src/RecordAllocations.h
+++ b/src/RecordAllocations.h
@@ -13,6 +13,9 @@ struct Allocation {
 
 std::vector<Allocation> RecordAllocations(const tflite::Model *model);
 
+TfLiteEvalTensor *GetEvalTensor(tflite::MicroInterpreter *interpreter, int i);
+TfLiteTensor *GetTensor(tflite::MicroInterpreter *interpreter, int i);
+
 }  // namespace tflmc
 
 #endif


### PR DESCRIPTION
This adds more overhead for the additional structures. Currently it seems like the operators require both tensor structs to exist. Maybe this will change in the future?