### PR TITLE
add ability to debug runtime allocations

### DIFF
--- a/src/Compiler.h
+++ b/src/Compiler.h
@@ -4,6 +4,7 @@
 #include <iostream>
 
 #include "MemMap.h"
+#include "RecordAllocations.h"
 #include "tensorflow/lite/micro/all_ops_resolver.h"
 #include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
@@ -89,6 +90,7 @@ class Compiler {
   std::vector<NodeInfo> nodes_;
   std::vector<int32_t> inputTensorIndices_;
   std::vector<int32_t> outputTensorIndices_;
+  std::vector<tflmc::Allocation> runtimeAllocations_;
 
   bool has_custom_ops = false;
   bool has_quantization = false;

--- a/src/RecordAllocations.h
+++ b/src/RecordAllocations.h
@@ -2,6 +2,7 @@
 #define TFLMCOMPILER_RECORDALLOCATIONS_H
 
 #include "tensorflow/lite/schema/schema_generated.h"
+#include "tensorflow/lite/micro/micro_interpreter.h"
 #include <cinttypes>
 
 namespace tflmc {


### PR DESCRIPTION
I ran into a bug caused by overriding the implementation of an operator only in the TF runtime, not in the TF linked to the compiler. The runtime implementation was doing different calls to AllocatePersistentBuffer than what the compiler expected. This caused weird data corruption issues.

This PR implements a way to prevent such issues in the future.