### PR TITLE
Fix registration of custom operators

### DIFF
--- a/src/Compiler.cc
+++ b/src/Compiler.cc
@@ -241,7 +241,7 @@ namespace micro {
 )";
     for (size_t i = 0; i < registrations_.size(); i++) {
       if (registrations_[i].code == tflite::BuiltinOperator_CUSTOM) {
-        wr << "extern TfLiteRegistration Register_"
+        wr << "extern TfLiteRegistration *Register_"
            << registrations_[i].custom_name << "(void);\n";
       }
     }
@@ -474,11 +474,13 @@ TfLiteStatus )"
     std::string opName;
     if (registrations_[i].code == tflite::BuiltinOperator_CUSTOM) {
       opName = registrations_[i].custom_name;
+      wr << "  registrations[OP_" << opName << "] = *(tflite::ops::micro::Register_"
+         << opName << "());\n";
     } else {
       opName = tflite::EnumNameBuiltinOperator(registrations_[i].code);
+      wr << "  registrations[OP_" << opName << "] = tflite::ops::micro::Register_"
+         << opName << "();\n";
     }
-    wr << "  registrations[OP_" << opName << "] = tflite::ops::micro::Register_"
-       << opName << "();\n";
   }
   wr << "\n";
   wr << "  for(size_t i = 0; i < " << nodes_.size() << R"(; ++i) {


### PR DESCRIPTION
While most of the tflite operators/kernels have a `Register_*` function returning the type TfLiteRegistration,
this is not the the case for custom TFLite Micro Operators. The `AddCustom()` function of the MicroMutableOpsResolver
still expects a pointer to a static struct.

My proposal to fix this issue:
- Update external function prototype for registering custom ops to use a pointer
- Dereference pointer when building the `registrations` array

References:
- https://github.com/tensorflow/tensorflow/commit/0bfe9a92d174f1bc4d99ac73e6ff23ffcba83aa4
- https://github.com/tensorflow/tensorflow/blob/31b768a3ed1ec731fb012d2053cde06c9d40b755/tensorflow/lite/micro/micro_mutable_op_resolver.h#L82
- https://github.com/tensorflow/tensorflow/blob/5dcfc51118817f27fad5246812d83e5dccdc5f72/tensorflow/lite/micro/micro_mutable_op_resolver.h#L497

Please correct me if I am wrong.